### PR TITLE
Destroy embedded view correctly

### DIFF
--- a/projects/ng-wormhole/src/lib/ng-wormhole.directive.ts
+++ b/projects/ng-wormhole/src/lib/ng-wormhole.directive.ts
@@ -9,7 +9,8 @@ import {
   OnChanges,
   SimpleChanges,
   HostBinding,
-  Inject
+  Inject,
+  OnDestroy
 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 


### PR DESCRIPTION
The embedded content is not being removed from the DOM correctly after the element with the ngWormhole directive is destroyed.